### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -12,10 +12,6 @@
 		"credits": "",
 		"logoFile": "",
 		"screenshots": [],
-		"parent": "ForgeRelocation",
-		"requiredMods": ["ForgeRelocation", "ForgeMultipart"],
-		"dependencies": ["ForgeRelocation", "ForgeMultipart"],
-		"dependants": [],
-		"useDependencyInformation": true
+		"parent": "ForgeRelocation"
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.